### PR TITLE
Added password error text field for notifying users 

### DIFF
--- a/materialtwostepslogin/src/main/java/com/unipiazza/material2stepslogin/fragments/SecondStepFragment.java
+++ b/materialtwostepslogin/src/main/java/com/unipiazza/material2stepslogin/fragments/SecondStepFragment.java
@@ -55,6 +55,7 @@ public class SecondStepFragment extends Fragment implements View.OnKeyListener {
     private RevealLinearLayout layoutSecond;
     private Button buttonLogin;
     private TextView pass_forget_description;
+    private TextView pass_error_description;
 
     @Nullable
     @Override
@@ -72,8 +73,10 @@ public class SecondStepFragment extends Fragment implements View.OnKeyListener {
         progressBarSecond = (ProgressBar) view.findViewById(R.id.progressBarSecond);
         layoutSecond = (RevealLinearLayout) view.findViewById(R.id.layoutSecond);
         buttonLogin = (Button) view.findViewById(R.id.buttonLogin);
+        pass_error_description = (TextView) view.findViewById(R.id.pass_error_description);
 
         progressBarSecond.setVisibility(View.GONE);
+        pass_error_description.setVisibility(View.GONE);
 
         if (mtsl != null) {
             email.setText(mtsl.getEmail());
@@ -107,6 +110,12 @@ public class SecondStepFragment extends Fragment implements View.OnKeyListener {
             if (mtsl.getEmail_text_color() != 0)
                 email.setTextColor(mtsl.getEmail_text_color());
 
+            if(mtsl.getPass_error_description_text() != 0)
+                pass_error_description.setText(mtsl.getPass_error_description_text());
+
+            if(mtsl.getPass_error_text_color() != 0)
+                pass_error_description.setTextColor(mtsl.getPass_error_text_color());
+
             view.setBackgroundColor(mtsl.getSecond_step_background_color());
         }
 
@@ -114,6 +123,7 @@ public class SecondStepFragment extends Fragment implements View.OnKeyListener {
             @Override
             public void onClick(View v) {
                 progressBarSecond.setVisibility(View.VISIBLE);
+                pass_error_description.setVisibility(View.GONE);
                 layoutSecond.setVisibility(View.GONE);
                 mListener.onLoginClicked(editTextPassword.getText().toString());
             }
@@ -122,6 +132,7 @@ public class SecondStepFragment extends Fragment implements View.OnKeyListener {
         pass_forget.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                pass_error_description.setVisibility(View.GONE);
                 mListener.onRecoverPasswordClicked();
             }
         });
@@ -176,6 +187,7 @@ public class SecondStepFragment extends Fragment implements View.OnKeyListener {
     public boolean onKey(View v, int keyCode, KeyEvent event) {
         switch (keyCode) {
             case KeyEvent.KEYCODE_BACK:
+                pass_error_description.setVisibility(View.GONE);
                 mListener.onBackToMail();
                 return false;
         }
@@ -185,5 +197,6 @@ public class SecondStepFragment extends Fragment implements View.OnKeyListener {
     public void wrongPassword() {
         progressBarSecond.setVisibility(View.GONE);
         layoutSecond.setVisibility(View.VISIBLE);
+        pass_error_description.setVisibility(View.VISIBLE);
     }
 }

--- a/materialtwostepslogin/src/main/java/com/unipiazza/material2stepslogin/view/MaterialTwoStepsLogin.java
+++ b/materialtwostepslogin/src/main/java/com/unipiazza/material2stepslogin/view/MaterialTwoStepsLogin.java
@@ -67,6 +67,8 @@ public class MaterialTwoStepsLogin extends LinearLayout {
     private int pass_forget_description_text;
     private int register_description_text_color;
     private int button_pass_forget_text;
+    private int pass_error_description_text;
+    private int pass_error_text_color;
     private int email_text_color;
     private int button_login_text;
 
@@ -334,5 +336,21 @@ public class MaterialTwoStepsLogin extends LinearLayout {
 
     public void setButton_login_text(int button_login_text) {
         this.button_login_text = button_login_text;
+    }
+
+    public int getPass_error_description_text() {
+        return pass_error_description_text;
+    }
+
+    public void setPass_error_description_text(int pass_error_description_text) {
+        this.pass_error_description_text = pass_error_description_text;
+    }
+
+    public int getPass_error_text_color() {
+        return pass_error_text_color;
+    }
+
+    public void setPass_error_text_color(int pass_error_text_color) {
+        this.pass_error_text_color = pass_error_text_color;
     }
 }

--- a/materialtwostepslogin/src/main/res/layout/second_login_view.xml
+++ b/materialtwostepslogin/src/main/res/layout/second_login_view.xml
@@ -56,6 +56,18 @@
             android:inputType="textPassword"
             android:padding="10dp" />
 
+        <TextView
+            android:id="@+id/pass_error_description"
+            style="@style/Base.TextAppearance.AppCompat.Caption"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="left"
+            android:paddingLeft="10dp"
+            android:paddingBottom="10dp"
+            android:text="@string/pass_error_description_text"
+            android:textSize="14dp"
+            android:textColor="#cc0000"/>
+
         <Button
             android:id="@+id/buttonLogin"
             android:layout_width="match_parent"

--- a/materialtwostepslogin/src/main/res/values/strings.xml
+++ b/materialtwostepslogin/src/main/res/values/strings.xml
@@ -19,4 +19,5 @@
     <string name="not_remember">Forgot password?</string>
     <string name="pass_forget">RECOVER YOUR PASSWORD</string>
     <string name="login">SIGN IN</string>
+    <string name="pass_error_description_text">Wrong password. Try again or click Forgot password to reset it</string>
 </resources>


### PR DESCRIPTION
Added password error text field for notifying users with a customizable error message when the password is wrong. 
A sample from google two step web login
![errmsg](https://user-images.githubusercontent.com/10791394/40118068-c03e50da-5910-11e8-86e4-9a8e1de56b01.gif)
